### PR TITLE
Pull bug fix

### DIFF
--- a/src/gui/dockmanager/pDockToolBar.cpp
+++ b/src/gui/dockmanager/pDockToolBar.cpp
@@ -105,9 +105,10 @@ void pDockToolBar::addDockWidget( QDockWidget* dockWidget, const QString& title,
 	}
 	
 	if ( !icon.isNull() ) {
-		dockWidget->toggleViewAction()->setIcon( icon );
 		dockWidget->setWindowIcon( icon );
 	}
+
+	dockWidget->toggleViewAction()->setIcon(dockWidget->windowIcon());
 
 	// create button
 	const Qt::ToolBarArea tbAreaCurrent = mManager->toolBarArea( this );


### PR DESCRIPTION
Hi

I fixed bug in the fresh. For mskv3, dock tool bar didn't have icons, because I didn't set it as parameters of addDock() method. 

Let's try to move changes in github way, via fork + pull request. 

One more thing. Your code 
void pDockToolBar::addDockWidget( QDockWidget\* dockWidget, const QString& title, const QIcon& icon )
{
    if ( !title.isEmpty() ) {
        dockWidget->toggleViewAction()->setText( title );
        dockWidget->setWindowTitle( title );
    }

```
if ( !icon.isNull() ) {
    dockWidget->setWindowIcon( icon );
}
```

It is side effect, user might be surprised, that you changed his original dock window text and icon. I think, fresh API would be more clear, if you excluded text and icon parameters from addDockWidget() method, so, there will be one and only one way to set it: 
1) dock->setWindowText(text), dock->setWindowIcon(icon)
2)  addDockWidget(dock)   // NO text and icon parameters
