### PR TITLE
include <QFrame> aim to compile gui pSpinBox component

### DIFF
--- a/src/gui/pSpinBox.cpp
+++ b/src/gui/pSpinBox.cpp
@@ -26,6 +26,7 @@
 #include "pSpinBox.h"
 #include "ui_pSpinBox.h"
 
+#include <QFrame>
 #include <QSlider>
 
 class Slider : public QSlider


### PR DESCRIPTION
from compile error message
"../../fresh.git/src/gui/pSpinBox.cpp:43:1: error: expected class-name before ‘{’ token"
